### PR TITLE
Edited color contrast button background color

### DIFF
--- a/frontend/src/app/pages/HomePage/Hero.tsx
+++ b/frontend/src/app/pages/HomePage/Hero.tsx
@@ -43,7 +43,7 @@ export default () => {
           </p>
                             <div className="mt-5 sm:mt-8 sm:flex sm:justify-center lg:justify-start">
                                 <div className="rounded-md shadow">
-                                    <a onClick={handleClick} href="/data" className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-white bg-green-600 hover:bg-green-700 md:py-4 md:text-lg md:px-10">
+                                    <a onClick={handleClick} href="/data" className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-white bg-green-700 hover:bg-green-800 md:py-4 md:text-lg md:px-10">
                                         Explore the data
               </a>
                                 </div>

--- a/frontend/src/app/pages/HomePage/Masthead.tsx
+++ b/frontend/src/app/pages/HomePage/Masthead.tsx
@@ -20,7 +20,7 @@ const Newsletter = () => {
           </p>
         <div className="mt-5 sm:mt-8 sm:flex sm:justify-center lg:justify-center">
           <div className="rounded-md shadow">
-            <a onClick={() => window.open('https://connectfamiliesnow.com/ourcampaigns')} className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-white bg-green-600 hover:bg-green-700 md:py-4 md:text-lg md:px-10 cursor-pointer">
+            <a onClick={() => window.open('https://connectfamiliesnow.com/ourcampaigns')} className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-white bg-green-700 hover:bg-green-800 md:py-4 md:text-lg md:px-10 cursor-pointer">
               Join a campaign
               </a>
           </div>


### PR DESCRIPTION
WebAim's WAVE tool flagged the background color of the "Explore the Data" and "Join a Campaign" buttons as being too low-contrast to meet WCAG's accessibility guidelines. Using Tailwind to make the background color one shade darker resolves this issue. 