### PR TITLE
Edited text to facilitate screenreader comprehension

### DIFF
--- a/frontend/src/app/pages/HomePage/Masthead.tsx
+++ b/frontend/src/app/pages/HomePage/Masthead.tsx
@@ -16,7 +16,7 @@ const Newsletter = () => {
           <h2 className="text-3xl sm:text-5xl font-extrabold text-gray-900">Free Communication</h2>
         </div>
         <p className="mt-3 text-base text-gray-500 sm:mt-5 sm:text-lg sm:mx-auto md:mt-5 md:text-xl lg:mx-0">
-          We share the goals of <a className="underline mr-1" href="https://connectfamiliesnow.com/">#ConnectFamiliesNow,</a> a collective of national, state, and local organizations fighting to connect families with incarcerated loved ones by making communication free.
+          We share the goals of <a className="underline mr-1" href="https://connectfamiliesnow.com/">ConnectFamiliesNow,</a> a collective of national, state, and local organizations fighting to connect families with incarcerated loved ones by making communication free.
           </p>
         <div className="mt-5 sm:mt-8 sm:flex sm:justify-center lg:justify-center">
           <div className="rounded-md shadow">


### PR DESCRIPTION
My NVDA screen reader read this page beautifully with just one exception. The text under "Our Goal" reads "We share the goals of #ConnectFamiliesNow, a collective ... ." The screen reader pronounces the organization name as "link number Connect Families now" or "visited link number Connect Families Now," which is confusing to the listener. I checked the Worth Rises and Connect Families now sites, and both refer to the organization in the test without the # sign except in the banner of the Connect Families Now site, which I suspect was done for visual/stylistic reasons alone. Therefore, I removed the # sign from the organization name in Masthead.tsx.  